### PR TITLE
[FEAT] 아이디 중복확인

### DIFF
--- a/src/controllers/UserController.ts
+++ b/src/controllers/UserController.ts
@@ -13,7 +13,7 @@ import { validationResult } from 'express-validator';
  *  @access public
  **/
 
-const createUser = async (req: Request, res: Response) => {
+const signUpUser = async (req: Request, res: Response) => {
   let client;
   const error = validationResult(req);
   if (!error.isEmpty()) {
@@ -25,7 +25,7 @@ const createUser = async (req: Request, res: Response) => {
   try {
     client = await db.connect(req);
     const userSignUpDto: UserSignUpDto = req.body;
-    const data = await UserService.createUser(client, userSignUpDto);
+    const data = await UserService.signUpUser(client, userSignUpDto);
     res.status(statusCode.OK).send(util.success(statusCode.OK, message.CREATE_USER_SUCCESS, data));
   } catch (error) {
     console.log(error);
@@ -100,7 +100,7 @@ const confirmUserId = async (req: Request, res: Response) => {
 }
 
 export default {
-  createUser,
+  signUpUser,
   signInUser,
   confirmUserId
 };

--- a/src/controllers/UserController.ts
+++ b/src/controllers/UserController.ts
@@ -1,14 +1,11 @@
-import statusCode from "../modules/statusCode";
-import util from "../modules/util";
-import { Request, Response } from "express";
-import message from "../modules/responseMessage";
-import db from "../loaders/db";
-import {
-  UserSignUpDto,
-  UserSignInDto,
-} from "../interfaces/IUser";
-import { UserService } from "../services";
-import { validationResult } from "express-validator";
+import statusCode from '../modules/statusCode';
+import util from '../modules/util';
+import { Request, Response } from 'express';
+import message from '../modules/responseMessage';
+import db from '../loaders/db';
+import { UserSignUpDto, UserSignInDto, UserConfirmIdDto } from '../interfaces/IUser';
+import { UserService } from '../services';
+import { validationResult } from 'express-validator';
 
 /**
  *  @route POST /user/
@@ -29,19 +26,12 @@ const createUser = async (req: Request, res: Response) => {
     client = await db.connect(req);
     const userSignUpDto: UserSignUpDto = req.body;
     const data = await UserService.createUser(client, userSignUpDto);
-    res
-      .status(statusCode.OK)
-      .send(util.success(statusCode.OK, message.CREATE_USER_SUCCESS, data));
+    res.status(statusCode.OK).send(util.success(statusCode.OK, message.CREATE_USER_SUCCESS, data));
   } catch (error) {
     console.log(error);
     res
       .status(statusCode.INTERNAL_SERVER_ERROR)
-      .send(
-        util.fail(
-          statusCode.INTERNAL_SERVER_ERROR,
-          message.INTERNAL_SERVER_ERROR
-        )
-      );
+      .send(util.fail(statusCode.INTERNAL_SERVER_ERROR, message.INTERNAL_SERVER_ERROR));
   } finally {
     if (client !== undefined) client.release();
   }
@@ -60,31 +50,57 @@ const signInUser = async (req: Request, res: Response) => {
     client = await db.connect(req);
     const userSignInDto: UserSignInDto = req.body;
     const data = await UserService.signInUser(client, userSignInDto);
-    if (data === "login_failed") {
+    if (data === 'login_failed') {
       res
         .status(statusCode.UNAUTHORIZED)
         .send(util.fail(statusCode.UNAUTHORIZED, message.SIGNIN_FAIL));
     } else {
-      res
-        .status(statusCode.OK)
-        .send(util.success(statusCode.OK, message.SIGNIN_SUCCESS, data));
+      res.status(statusCode.OK).send(util.success(statusCode.OK, message.SIGNIN_SUCCESS, data));
     }
   } catch (error) {
     console.log(error);
     res
       .status(statusCode.INTERNAL_SERVER_ERROR)
-      .send(
-        util.fail(
-          statusCode.INTERNAL_SERVER_ERROR,
-          message.INTERNAL_SERVER_ERROR
-        )
-      );
+      .send(util.fail(statusCode.INTERNAL_SERVER_ERROR, message.INTERNAL_SERVER_ERROR));
   } finally {
     if (client !== undefined) client.release();
   }
 };
 
+const confirmUserId = async (req: Request, res: Response) => {
+  let client;
+  const error = validationResult(req);
+  if (!error.isEmpty()) {
+    return res
+    .status(statusCode.BAD_REQUEST)
+    .send(util.fail(statusCode.BAD_REQUEST, message.NULL_VALUE));
+  }
+
+  try {
+    client = await db.connect(req);
+    const userConfirmIdDto: UserConfirmIdDto = req.body;
+    const data = await UserService.confirmUserId(client, userConfirmIdDto);
+    if (data === 'available_Id') {
+      res
+      .status(statusCode.OK)
+      .send(util.success(statusCode.OK, message.AVAILABLE_USER_ID));
+    } else {
+      res
+      .status(statusCode.CONFLICT)
+      .send(util.success(statusCode.CONFLICT, message.ID_ALREADY_EXISTS));
+    }
+  } catch(error) {
+    console.log(error);
+    res
+    .status(statusCode.INTERNAL_SERVER_ERROR)
+    .send(util.fail(statusCode.INTERNAL_SERVER_ERROR, message.INTERNAL_SERVER_ERROR));
+  } finally {
+    if (client !== undefined) client.release();
+  }
+}
+
 export default {
   createUser,
   signInUser,
+  confirmUserId
 };

--- a/src/interfaces/IUser.ts
+++ b/src/interfaces/IUser.ts
@@ -3,7 +3,6 @@ export interface UserSignUpDto {
   age: string;
   password: string;
 }
-
 export interface UserSignUpResponseDto {
   accessToken: string;
 }
@@ -11,7 +10,9 @@ export interface UserSignInDto {
   email: string;
   password: string;
 }
-
 export interface UserSignInResponseDto {
   accessToken: string;
+}
+export interface UserConfirmIdDto {
+  email: string;
 }

--- a/src/interfaces/IUser.ts
+++ b/src/interfaces/IUser.ts
@@ -1,5 +1,5 @@
 export interface UserSignUpDto {
-  email: string;
+  user_id: string;
   age: string;
   password: string;
 }
@@ -7,12 +7,12 @@ export interface UserSignUpResponseDto {
   accessToken: string;
 }
 export interface UserSignInDto {
-  email: string;
+  user_id: string;
   password: string;
 }
 export interface UserSignInResponseDto {
   accessToken: string;
 }
 export interface UserConfirmIdDto {
-  email: string;
+  user_id: string;
 }

--- a/src/modules/responseMessage.ts
+++ b/src/modules/responseMessage.ts
@@ -7,6 +7,8 @@ const message = {
   // 유저 관련
   CREATE_USER_SUCCESS: "유저 생성 성공",
   UPDATE_USER_SUCCESS: "유저 업데이트 성공",
+  AVAILABLE_USER_ID: "아이디 사용 가능",
+  ID_ALREADY_EXISTS: "아이디 중복",
 
   // 토큰 관련
   NULL_VALUE_TOKEN: "토큰이 없습니다",

--- a/src/routes/UserRouter.ts
+++ b/src/routes/UserRouter.ts
@@ -7,22 +7,22 @@ const router = Router();
 router.post(
   "/signUp",
   [
-    body("email").notEmpty(),
+    body("user_id").notEmpty(),
     body("age").notEmpty(),
     body("password").notEmpty()
   ],
-  UserController.createUser
+  UserController.signUpUser
 );
 
 router.get(
   "/signIn",
-  [body("email").notEmpty(), body("password").notEmpty()],
+  [body("user_id").notEmpty(), body("password").notEmpty()],
   UserController.signInUser
 );
 
 router.get(
   "/confirmId",
-  [body("email").notEmpty()],
+  [body("user_id").notEmpty()],
   UserController.confirmUserId
 )
 

--- a/src/routes/UserRouter.ts
+++ b/src/routes/UserRouter.ts
@@ -20,4 +20,10 @@ router.get(
   UserController.signInUser
 );
 
+router.get(
+  "/confirmId",
+  [body("email").notEmpty()],
+  UserController.confirmUserId
+)
+
 export default router;

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -4,6 +4,7 @@ import {
   UserSignUpResponseDto,
   UserSignInDto,
   UserSignInResponseDto,
+  UserConfirmIdDto,
 } from '../interfaces/IUser';
 import jwtHandler from '../modules/jwtHandler';
 import bcrypt from 'bcryptjs';
@@ -65,7 +66,31 @@ const signInUser = async (
   }
 };
 
+const confirmUserId = async (client: any, userConfirmIdDto: UserConfirmIdDto): Promise<string> => {
+  try {
+    const { rows: user } = await client.query(
+      `
+        SELECT *
+        FROM "user" as u
+        WHERE u.email = $1
+      `,
+      [userConfirmIdDto.email],
+    );
+
+    console.log('user: ', user);
+    if (user[0]) {
+      return 'already_exist';
+    } else {
+      return 'available_Id';
+    }
+  } catch (error) {
+    console.log(error);
+    throw error;
+  }
+};
+
 export default {
   createUser,
   signInUser,
+  confirmUserId,
 };

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -9,7 +9,7 @@ import {
 import jwtHandler from '../modules/jwtHandler';
 import bcrypt from 'bcryptjs';
 
-const createUser = async (
+const signUpUser = async (
   client: any,
   userSignUpDto: UserSignUpDto,
 ): Promise<UserSignUpResponseDto> => {
@@ -18,11 +18,11 @@ const createUser = async (
     const encryptedPassword = await bcrypt.hash(userSignUpDto.password, salt);
     const { rows: user } = await client.query(
       `
-            INSERT INTO "user" (email, age, password)
+            INSERT INTO "user" (user_id, age, password)
             VALUES ($1, $2, $3)
             RETURNING id
             `,
-      [userSignUpDto.email, userSignUpDto.age, encryptedPassword],
+      [userSignUpDto.user_id, userSignUpDto.age, encryptedPassword],
     );
     const accessToken = jwtHandler.getToken(user[0].id);
     const data: UserSignUpResponseDto = {
@@ -45,9 +45,9 @@ const signInUser = async (
       `
         SELECT *
         FROM "user" as u
-        WHERE u.email = $1
+        WHERE u.user_id = $1
       `,
-      [userSignInDto.email],
+      [userSignInDto.user_id],
     );
 
     const isMatch = await bcrypt.compare(userSignInDto.password, user[0].password);
@@ -72,9 +72,9 @@ const confirmUserId = async (client: any, userConfirmIdDto: UserConfirmIdDto): P
       `
         SELECT *
         FROM "user" as u
-        WHERE u.email = $1
+        WHERE u.user_id = $1
       `,
-      [userConfirmIdDto.email],
+      [userConfirmIdDto.user_id],
     );
 
     console.log('user: ', user);
@@ -90,7 +90,7 @@ const confirmUserId = async (client: any, userConfirmIdDto: UserConfirmIdDto): P
 };
 
 export default {
-  createUser,
+  signUpUser,
   signInUser,
   confirmUserId,
 };


### PR DESCRIPTION
## 🌱 Related Issue
- Close #11 

## ✏️ Task
- 아이디 중복확인 기능 생성
- 변수명 변경: email -> user_id, createUser -> signUpUser
- DB user 테이블 - email column명 -> user_id로 수정

## 💡 Review Point
- 구글링 해보니 409(Conflict)는 리소스 충돌을 의미하고, 403(Forbidden)은 데이터 유효성 체크할 때 사용하기 때문에 중복 아이디 체크에서는 409가 더 적합하다고 하여 중복된 아이디일 경우 409를 사용했습니다!